### PR TITLE
Pointing to available Centos mirrorlist

### DIFF
--- a/aws-patch-manager/02_LABINSTRUCTIONS/STAGE2 - AWS Managed Instances.md
+++ b/aws-patch-manager/02_LABINSTRUCTIONS/STAGE2 - AWS Managed Instances.md
@@ -99,6 +99,10 @@ This will connect you into the `AWS-CENTOS` instance
 
 make sure python3 works  
 
+run following commands to point to the available mirrorlist before running next commands
+
+`sudo sed -i -e "s|mirrorlist=|#mirrorlist=|g" /etc/yum.repos.d/CentOS-*`
+`sudo sed -i -e "s|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g" /etc/yum.repos.d/CentOS-*`
 
 for centos the command to install the Systems Manager Agent is   
 


### PR DESCRIPTION
Since Centos has reached EOL and its default mirrorlist is removed, we need to explicitly point to available mirrorlist. 
Currently it is giving - Error: Failed to download metadata for repo 'AppStream': Cannot prepare internal mirrorlist: No URLs in mirrorlist
This error will be resolved with this update.