### PR TITLE
Replace non-standard double quotes with standard double quotes

### DIFF
--- a/aws-codepipeline-catpipeline/02_LABINSTRUCTIONS/STAGE1-CODECOMMIT.md
+++ b/aws-codepipeline-catpipeline/02_LABINSTRUCTIONS/STAGE1-CODECOMMIT.md
@@ -54,10 +54,10 @@ Delete the zip file
 then from the terminal move into that folder  
 Run these commands.  
 
-``` 
-git add -A . 
-git commit -m “container of cats” 
-git push 
+```
+git add -A .
+git commit -m "container of cats"
+git push
 
 ```
 

--- a/aws-codepipeline-catpipeline/02_LABINSTRUCTIONS/STAGE2-CODEBUILD.md
+++ b/aws-codepipeline-catpipeline/02_LABINSTRUCTIONS/STAGE2-CODEBUILD.md
@@ -132,10 +132,10 @@ phases:
 
 Then add this locally, commit and stage
 
-``` 
+```
 git add -A .
-git commit -m “add buildspec.yml”
-git push 
+git commit -m "add buildspec.yml"
+git push
 ```
 
 ## TEST THE CODEBUILD PROJECT


### PR DESCRIPTION
There are non standard (ie “) double quotes that need to be replaced with standard double quotes.

These cause the commit messages to fail if copy and pasting to the terminal.

Whitespace also removed.