### PR TITLE
add $ACCOUNT_ID environment variable for codecommit; minor instruction improvements

### DIFF
--- a/aws-codepipeline-catpipeline/02_LABINSTRUCTIONS/STAGE2-CODEBUILD.md
+++ b/aws-codepipeline-catpipeline/02_LABINSTRUCTIONS/STAGE2-CODEBUILD.md
@@ -167,7 +167,8 @@ Run `aws ecr get-login-password --region us-east-1`, this command gives us login
 # get the account id from the metadata server
 export ACCOUNT_ID=$(curl -s http://169.254.169.254/latest/dynamic/instance-identity/document | jq -r .accountId)
 # sign in to ECR
-aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin ACCOUNTID_REPLACEME.dkr.ecr.us-east-1.amazonaws.com```
+aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin ACCOUNTID_REPLACEME.dkr.ecr.us-east-1.amazonaws.com
+```
 
 Go to the ECR console (https://us-east-1.console.aws.amazon.com/ecr/repositories?region=us-east-1)
 Repositories

--- a/aws-codepipeline-catpipeline/02_LABINSTRUCTIONS/STAGE2-CODEBUILD.md
+++ b/aws-codepipeline-catpipeline/02_LABINSTRUCTIONS/STAGE2-CODEBUILD.md
@@ -4,41 +4,41 @@ Welcome to stage 2 of this demo where you will configure the Elastic Container R
 
 ## CREATE A PRIVATE REPOSITORY
 
-Move to the Container Services console, the repositories (https://us-east-1.console.aws.amazon.com/ecr/repositories?region=us-east-1)  
-Create a Repository.  
-It should be a private repository.  
-..and for the alias/name pick 'catpipeline'.  
-Note down the URL and name (it should match the above name). 
+Move to the Container Services console, the repositories (https://us-east-1.console.aws.amazon.com/ecr/repositories?region=us-east-1)
+Create a Repository.
+It should be a private repository.
+..and for the alias/name pick 'catpipeline'.
+Note down the URL and name (it should match the above name).
 
-This is the repository that codebuild will store the docker image in, created from the codecommit repo.   
+This is the repository that codebuild will store the docker image in, created from the codecommit repo.
 
 ## SETUP A CODEBUILD PROJECT
 
 Next, we will configure a codebuild project to take what's in the codecommit repo, build a docker image & store it within ECR in the above repository.
 
-Move to the codebuild console (https://us-east-1.console.aws.amazon.com/codesuite/codebuild/projects?region=us-east-1)  
+Move to the codebuild console (https://us-east-1.console.aws.amazon.com/codesuite/codebuild/projects?region=us-east-1)
 
 Create code build project
-  
+
 ### PROJECT CONFIGURATION
-For `Project name` put `catpipeline-build`.  
-Leave all other options in this section as default.  
+For `Project name` put `catpipeline-build`.
+Leave all other options in this section as default.
 
 ### SOURCE
-For `Source Provider` choose `AWS CodeCommit`  
-For `Repository` choose the repo you created in stage 1  
-Check the `Branch` checkbox and pick the branch from the `Branch` dropdown (there should only be one).  
+For `Source Provider` choose `AWS CodeCommit`
+For `Repository` choose the repo you created in stage 1
+Check the `Branch` checkbox and pick the branch from the `Branch` dropdown (there should only be one).
 
 ### ENVIRONMENT
-for `Environment image` pick `Managed Image`  
-Under `Operating system` pick `Amazon Linux 2`  
+for `Environment image` pick `Managed Image`
+Under `Operating system` pick `Amazon Linux 2`
 under `Runtime(s)` pick `Standard`
-under `Image` pick `aws/codebuild/amazonlinux2-x86_64-standard:X.0` where X is the highest number.  
-Under `Image version` `Always use the latest image for this runtime version`  
-Under `Envrironment Type` pick `Linux`  
-Check the `Privileged` box (Because we're creating a docker image)  
-For `Service role` pick `New Service Role` and leave the default suggested name which should be something like `codebuild-catpipeline-service-role`  
-Expand `Additional Configuration`  
+under `Image` pick `aws/codebuild/amazonlinux2-x86_64-standard:X.0` where X is the highest number.
+Under `Image version` `Always use the latest image for this runtime version`
+Under `Envrironment Type` pick `Linux`
+Check the `Privileged` box (Because we're creating a docker image)
+For `Service role` pick `New Service Role` and leave the default suggested name which should be something like `codebuild-catpipeline-service-role`
+Expand `Additional Configuration`
 We're going to be adding some environment variables
 
 Add the following:-
@@ -53,31 +53,31 @@ IMAGE_REPO_NAME with a value of your ECR_REPO_NAME_REPLACEME
 ### BUILDSPEC
 The buildspec.yml file is what tells codebuild how to build your code.. the steps involved, what things the build needs, any testing and what to do with the output (artifacts).
 
-A build project can have build commands included... or, you can point it at a buildspec.yml file, i.e one which is hosted on the same repository as the code.. and that's what you're going to do.  
+A build project can have build commands included... or, you can point it at a buildspec.yml file, i.e one which is hosted on the same repository as the code.. and that's what you're going to do.
 
-Check `Use a buildspec file`  
-you don't need to enter a name as it will use by default buildspec.yml in the root of the repo. If you want to use a different name, or have the file located elsewhere (i.e in a folder) you need to specify this here.  
+Check `Use a buildspec file`
+you don't need to enter a name as it will use by default buildspec.yml in the root of the repo. If you want to use a different name, or have the file located elsewhere (i.e in a folder) you need to specify this here.
 
 ### ARTIFACTS
 No changes to this section, as we're building a docker image and have no testing yet, this part isn't needed.
 
 ### LOGS
 
-This is where the logging is configured, to Cloudwatch logs or S3 (optional).  
+This is where the logging is configured, to Cloudwatch logs or S3 (optional).
 
-For `Groupname` enter `a4l-codebuild`  
-and for `Stream Name` enter `catpipeline`  
+For `Groupname` enter `a4l-codebuild`
+and for `Stream Name` enter `catpipeline`
 
 Create the build Project
 
 ## BUILD SECURITY AND PERMISSIONS
 
-Our build project will be accessing ECR to store the resultant docker image, and we need to ensure it has the permissons to do that. The build process will use an IAM role created by codebuild, so we need to update that roles permissions with ALLOWS for ECR.  
+Our build project will be accessing ECR to store the resultant docker image, and we need to ensure it has the permissons to do that. The build process will use an IAM role created by codebuild, so we need to update that roles permissions with ALLOWS for ECR.
 
-Go to the IAM Console (https://us-east-1.console.aws.amazon.com/iamv2/home#/home)  
-Then Roles  
-Locate and click the codebuild cat pipeline role i.e. `codebuild-catpipeline-build-service-role`  
-Click the `Permissions` tab and we need to Add a permission and it will be an `inline policy`  
+Go to the IAM Console (https://us-east-1.console.aws.amazon.com/iamv2/home#/home)
+Then Roles
+Locate and click the codebuild cat pipeline role i.e. `codebuild-catpipeline-build-service-role`
+Click the `Permissions` tab and we need to Add a permission and it will be an `inline policy`
 Select to edit the raw `JSON` and delete the skeleton JSON, replacing it with
 
 ```
@@ -100,14 +100,14 @@ Select to edit the raw `JSON` and delete the skeleton JSON, replacing it with
 }
 ```
 
-Move on and review the policy.  
+Move on and review the policy.
 Name it `Codebuild-ECR` and create the policy
-This means codebuild can now access ECR.  
+This means codebuild can now access ECR.
 
 ## BUILDSPEC.YML
 
-Create a file in the local copy of the `catpipeline-codecommit-XXX` repo called `buildspec.yml`  
-Into this file add the following contents :-  
+Create a file in the local copy of the `catpipeline-codecommit-XXX` repo called `buildspec.yml`
+Into this file add the following contents :-
 
 ```
 version: 0.2
@@ -120,9 +120,9 @@ phases:
   build:
 	commands:
 	  - echo Build started on `date`
-	  - echo Building the Docker image...          
+	  - echo Building the Docker image...
 	  - docker build -t $IMAGE_REPO_NAME:$IMAGE_TAG .
-	  - docker tag $IMAGE_REPO_NAME:$IMAGE_TAG $AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/$IMAGE_REPO_NAME:$IMAGE_TAG      
+	  - docker tag $IMAGE_REPO_NAME:$IMAGE_TAG $AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/$IMAGE_REPO_NAME:$IMAGE_TAG
   post_build:
 	commands:
 	  - echo Build completed on `date`
@@ -132,34 +132,34 @@ phases:
 
 Then add this locally, commit and stage
 
-``` 
+```
 git add -A .
 git commit -m “add buildspec.yml”
-git push 
+git push
 ```
 
 ## TEST THE CODEBUILD PROJECT
 
-Open the CodeBuild console (https://us-east-1.console.aws.amazon.com/codesuite/codebuild/projects?region=us-east-1)  
-Open `catpipeline-build`  
-Start Build  
-Check progress under phase details tab and build logs tab  
+Open the CodeBuild console (https://us-east-1.console.aws.amazon.com/codesuite/codebuild/projects?region=us-east-1)
+Open `catpipeline-build`
+Start Build
+Check progress under phase details tab and build logs tab
 
 ## TEST THE DOCKER IMAGE
 
 Use this link to deploy an EC2 instance with docker installed (https://console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/quickcreate?templateURL=https://learn-cantrill-labs.s3.amazonaws.com/aws-codepipeline-catpipeline/ec2docker.yaml&stackName=DOCKER) accept all details, check the checkbox and create the stack.
-Wait for this to move into the `CREATE_COMPLETE` state before continuing.  
+Wait for this to move into the `CREATE_COMPLETE` state before continuing.
 
-Move to the EC2 Console ( https://us-east-1.console.aws.amazon.com/ec2/home?region=us-east-1#Home: )  
-Instances  
-Select `A4L-PublicEC2`, right click, connect  
-Choose EC2 Instance Connect, leave everything with defaults and connect.  
+Move to the EC2 Console ( https://us-east-1.console.aws.amazon.com/ec2/home?region=us-east-1#Home: )
+Instances
+Select `A4L-PublicEC2`, right click, connect
+Choose EC2 Instance Connect, leave everything with defaults and connect.
 
 
 Docker should already be preinstalled and the EC2 instance has a role which gives ECR permissions which you will need for the next step.
 
 test docker via  `docker ps` command
-it should output an empty list  
+it should output an empty list
 
 
 run a `aws ecr get-login-password --region us-east-1`, this command gives us login information for ECR which can be used with the docker command. To use it use this command.
@@ -168,25 +168,25 @@ you will need to replace the placeholder with your AWS Account ID (with no dashe
 
 `aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin ACCOUNTID_REPLACEME.dkr.ecr.us-east-1.amazonaws.com`
 
-Go to the ECR console (https://us-east-1.console.aws.amazon.com/ecr/repositories?region=us-east-1)  
-Repositories  
-Click the `catpipeline` repository  
-For `latest` copy the URL into your clipboard  
+Go to the ECR console (https://us-east-1.console.aws.amazon.com/ecr/repositories?region=us-east-1)
+Repositories
+Click the `catpipeline` repository
+For `latest` copy the URL into your clipboard
 
 run the command below pasting in your clipboard after docker p
-`docker pull ` but paste in your clipboard after the space, i.e 
-`docker pull ACCOUNTID_REPLACEME.dkr.ecr.us-east-1.amazonaws.com/catpipeline:latest` (this is an example, you will need your image URI)  
+`docker pull ` but paste in your clipboard after the space, i.e
+`docker pull ACCOUNTID_REPLACEME.dkr.ecr.us-east-1.amazonaws.com/catpipeline:latest` (this is an example, you will need your image URI)
 
 run `docker images` and copy the image ID into your clipboard for the `catpipeline` docker image
 
-run the following command replacing the placeholder with the image ID you copied above.  
+run the following command replacing the placeholder with the image ID you copied above.
 
 `docker run -p 80:80 IMAGEID_REPLACEME`
 
-Move back to the EC2 console tab  
-Click `Instances` and get the public IPv4 address for the A4L-PublicEC2 instance.  
-open that IP in a new tab, ensuring it's http://IP not https://IP  
-You should see the docker container running, with cats in containers... if so, this means your automated build process is working.  
+Move back to the EC2 console tab
+Click `Instances` and get the public IPv4 address for the A4L-PublicEC2 instance.
+open that IP in a new tab, ensuring it's http://IP not https://IP
+You should see the docker container running, with cats in containers... if so, this means your automated build process is working.
 
 
 

--- a/aws-codepipeline-catpipeline/02_LABINSTRUCTIONS/STAGE2-CODEBUILD.md
+++ b/aws-codepipeline-catpipeline/02_LABINSTRUCTIONS/STAGE2-CODEBUILD.md
@@ -168,7 +168,7 @@ yum install jq -y
 # get the account id from the metadata server
 export ACCOUNT_ID=$(curl -s http://169.254.169.254/latest/dynamic/instance-identity/document | jq -r .accountId)
 # sign in to ECR
-aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin ACCOUNTID_REPLACEME.dkr.ecr.us-east-1.amazonaws.com
+aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin $ACCOUNT_ID.dkr.ecr.us-east-1.amazonaws.com
 ```
 
 Go to the ECR console (https://us-east-1.console.aws.amazon.com/ecr/repositories?region=us-east-1)

--- a/aws-codepipeline-catpipeline/02_LABINSTRUCTIONS/STAGE2-CODEBUILD.md
+++ b/aws-codepipeline-catpipeline/02_LABINSTRUCTIONS/STAGE2-CODEBUILD.md
@@ -158,15 +158,16 @@ Choose EC2 Instance Connect, leave everything with defaults and connect.
 
 Docker should already be preinstalled and the EC2 instance has a role which gives ECR permissions which you will need for the next step.
 
-test docker via  `docker ps` command
-it should output an empty list
+Run `sudo -i` to become root and then test docker via  `docker ps` command.  It should output an empty list.
 
 
-run a `aws ecr get-login-password --region us-east-1`, this command gives us login information for ECR which can be used with the docker command. To use it use this command.
+Run `aws ecr get-login-password --region us-east-1`, this command gives us login information for ECR which can be used with the docker command. To use it use this command, you will need to replace the placeholder with your AWS Account ID (with no dashes)
 
-you will need to replace the placeholder with your AWS Account ID (with no dashes)
-
-`aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin ACCOUNTID_REPLACEME.dkr.ecr.us-east-1.amazonaws.com`
+```yum install jq -y
+# get the account id from the metadata server
+export ACCOUNT_ID=$(curl -s http://169.254.169.254/latest/dynamic/instance-identity/document | jq -r .accountId)
+# sign in to ECR
+aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin ACCOUNTID_REPLACEME.dkr.ecr.us-east-1.amazonaws.com```
 
 Go to the ECR console (https://us-east-1.console.aws.amazon.com/ecr/repositories?region=us-east-1)
 Repositories
@@ -174,8 +175,8 @@ Click the `catpipeline` repository
 For `latest` copy the URL into your clipboard
 
 run the command below pasting in your clipboard after docker p
-`docker pull ` but paste in your clipboard after the space, i.e
-`docker pull ACCOUNTID_REPLACEME.dkr.ecr.us-east-1.amazonaws.com/catpipeline:latest` (this is an example, you will need your image URI)
+`docker pull` but paste in your clipboard after the space, i.e
+`docker pull $ACCOUNT_ID.dkr.ecr.us-east-1.amazonaws.com/catpipeline:latest` (this is an example, you will need your image URI)
 
 run `docker images` and copy the image ID into your clipboard for the `catpipeline` docker image
 
@@ -187,10 +188,3 @@ Move back to the EC2 console tab
 Click `Instances` and get the public IPv4 address for the A4L-PublicEC2 instance.
 open that IP in a new tab, ensuring it's http://IP not https://IP
 You should see the docker container running, with cats in containers... if so, this means your automated build process is working.
-
-
-
-
-
-
-

--- a/aws-codepipeline-catpipeline/02_LABINSTRUCTIONS/STAGE2-CODEBUILD.md
+++ b/aws-codepipeline-catpipeline/02_LABINSTRUCTIONS/STAGE2-CODEBUILD.md
@@ -163,7 +163,8 @@ Run `sudo -i` to become root and then test docker via  `docker ps` command.  It 
 
 Run `aws ecr get-login-password --region us-east-1`, this command gives us login information for ECR which can be used with the docker command. To use it use this command, you will need to replace the placeholder with your AWS Account ID (with no dashes)
 
-```yum install jq -y
+```
+yum install jq -y
 # get the account id from the metadata server
 export ACCOUNT_ID=$(curl -s http://169.254.169.254/latest/dynamic/instance-identity/document | jq -r .accountId)
 # sign in to ECR


### PR DESCRIPTION
couple tiny suggestions:
- `jq` could be installed by a cloud init script as part of the stack initialization
- a lot of these PNGs are unnecessarily large.  I would crush them for you, but it would just make the repo even bigger.  Recommend `optipng -o7` before they even get committed; would be glad to write a commit hook if interested.