### PR TITLE
Update STAGE3 - Add RDS and Update the LT.md

### DIFF
--- a/aws-elastic-wordpress-evolution/02_LABINSTRUCTIONS/STAGE3 - Add RDS and Update the LT.md
+++ b/aws-elastic-wordpress-evolution/02_LABINSTRUCTIONS/STAGE3 - Add RDS and Update the LT.md
@@ -37,7 +37,7 @@ Click `Databases`
 Click `Create Database`  
 Click `Standard Create`  
 Click `MySql`  
-Under `Version` select `MySQL 8.0.28` (best aurora compatability for snapshot migrations)  
+Under `Version` select `MySQL 8.0.23` (best aurora compatability for snapshot migrations)  
 
 Scroll down and select `Free Tier` under templates
 _this ensures there will be no costs for the database but it will be single AZ only_


### PR DESCRIPTION
In "STAGE 3B - Create RDS Instance" of the "aws-elastic-wordpress-evolution" you suggest to select MySQL version 8.0.28 for best Aurora compatibility for snapshot migrations. However when in stage 6 I try to execute the migrate snapshot action it fails with error connected to MySQL engine compatibility issue between snapshot MySQL 8.0.28 and Aurora MySQL 8.0.23 (there is no way to pick another MySQL version for Aurora). I fixed this by creating a new RDS MySQL 8.0.23 instance, migrating the WordPress DB on this new RDS instance and then catching up with your instructions