### PR TITLE
Fix some typos / invalid settings in aws-elastic-wordpress-evolution

### DIFF
--- a/aws-elastic-wordpress-evolution/02_LABINSTRUCTIONS/STAGE2 - Automate the build using a Launch Template.md
+++ b/aws-elastic-wordpress-evolution/02_LABINSTRUCTIONS/STAGE2 - Automate the build using a Launch Template.md
@@ -118,7 +118,7 @@ copy the `IPv4 Public IP` into your clipboard, don't click the link to open, thi
 Open that IP in a new tab  
 You should see the WordPress welcome page  
 
-## Perform Initial COnfiguration and make a post
+## Perform Initial Configuration and make a post
 
 in `Site Title` enter `Catagram`  
 in `Username` enter `admin`

--- a/aws-elastic-wordpress-evolution/02_LABINSTRUCTIONS/STAGE4 - Add EFS and Update the LT.md
+++ b/aws-elastic-wordpress-evolution/02_LABINSTRUCTIONS/STAGE4 - Add EFS and Update the LT.md
@@ -19,7 +19,7 @@ for `Transition out of IA` set to `None`
 Untick `Enable encryption of data at rest` .. in production you would leave this on, but for this demo which focusses on architecture it simplifies the implementation. 
 
 Scroll down...  
-For `throughput modes` choose `Basic`   
+For `throughput modes` choose `Bursting`   
 Expand `Additional Settings` and ensure `Performance Mode` is set to `General Purpose`  
 Click `Next`
 

--- a/aws-simple-site2site-vpn/02_LABINSTRUCTIONS/STAGE2.md
+++ b/aws-simple-site2site-vpn/02_LABINSTRUCTIONS/STAGE2.md
@@ -137,7 +137,7 @@ Click `Save`.
 
 # initially connect the VPN Tunnels and IPSec  
 
-Click `Apple Changes`.   
+Click `Apply Changes`.   
 Click `Status` => `IPSec`.   
 Click `Connect P1 and P2s` next to both lines.   
 


### PR DESCRIPTION
I was recently following the advanced demo and noticed the throughput mode for EFS was set to `Basic` which is not a valid value at this time. I corrected it to `Bursting` which is what is also displayed on the video.

I also have some feedback in case it's useful:

- I started the demo following the instructions from the video but got stuck when I had to install the wordpress dependencies. The issue was that I had launched the instance using the AMI that is explicitly stated in the video, which is the `Amazon Linux 2 AMI (HVM)`. In the documentation it correctly says to use the `Amazon Linux 2023 AMI`. I guess it's not easy to update the videos just to make a simple change, but it could save future viewers some time!

- On stage 3, we are instructed to delete the parameter for the database endpoint instead of updating it (when moving from local db to rds). It is never explained why this cannot just be updated, so I tried updating it just to see what would happen and everything worked as intended so I never understood why the need to explicitly delete the parameter. Maybe it was the case in earlier versions of the parameter store and now this instruction can be updated to a refresh? I would love to know the reasoning for the delete / recreate if this is not the case.

I will use  this opportunity to say thank you for your amazing course (SAA-CO3), I am really enjoying it so far!