### PR TITLE
Add dependson to alb

### DIFF
--- a/00-aws-simple-demos/aws-alb-session-stickiness/01_LABSETUP/ALBSTICKINESS.yaml
+++ b/00-aws-simple-demos/aws-alb-session-stickiness/01_LABSETUP/ALBSTICKINESS.yaml
@@ -168,7 +168,7 @@ Resources:
         SecurityGroupIds: 
           - !Ref SGWEB
         UserData:
-          Fn::Base64: !Sub |
+          Fn::Base64: |
             #!/bin/bash -xe
 
             # STEP 1 - Updates

--- a/00-aws-simple-demos/aws-alb-session-stickiness/01_LABSETUP/ALBSTICKINESS.yaml
+++ b/00-aws-simple-demos/aws-alb-session-stickiness/01_LABSETUP/ALBSTICKINESS.yaml
@@ -227,6 +227,7 @@ Resources:
       TargetGroupARNs:
         - !Ref ALBTG
   ALB:
+    DependsOn: InternetGatewayAttachment
     Type: AWS::ElasticLoadBalancingV2::LoadBalancer
     Properties: 
       IpAddressType: "ipv4"


### PR DESCRIPTION
## Purpose of PR
This PR proposes a fix to an issue that was reported in slack:
https://techstudyslack.slack.com/archives/C010173PTGU/p1693031828964669

The issue was encountered during deployment of `ALBSTICKINESS.yaml` stack, with the following error message:
```
VPC has no internet gateway (Service: AmazonElasticLoadBalancing; Status Code: 400; Error Code: InvalidSubnet
```
the `ALB` resource in the stack fails to deploy, because the `InternetGatewayAttachment` resource wasn't being created before the ALB resource.

## Proposed fix to issue
The proposed fix to this issue is to add a `DependsOn: InternetGatewayAttachment` attribute to the `ALB` resource to add `InternetGatewayAttachment` resource as a dependency for `ALB` resource.

**N.B:**
Also included a minor improvement to stack template, suggested by `cfn-lint` tool, to remove the use of `!Sub` intrinsic function from `UserData` attribute in `WEBLaunchTemplate` resource.
