### PR TITLE
Fix VPC Security Group typo

### DIFF
--- a/aws-elastic-wordpress-evolution/02_LABINSTRUCTIONS/STAGE3 - Add RDS and Update the LT.md
+++ b/aws-elastic-wordpress-evolution/02_LABINSTRUCTIONS/STAGE3 - Add RDS and Update the LT.md
@@ -53,7 +53,7 @@ under `Connectivity`, `Network type` select `IPv4`
 under `Connectivity`, `Virtual private cloud (VPC)` select `A4LVPC`  
 under `Subnet group` that `wordpressrdssubnetgroup` is selected  
 Make sure `Public Access` is set to `No`  
-Under `VPC security groups` make sure `choose existing` is selected, remove `default` and add `A4LVPC-SG-Database`  
+Under `VPC security groups` make sure `choose existing` is selected, remove `default` and add `A4LVPC-SGDatabase`  
 Under `Availability Zone` set `us-east-1a`  
 
 **IMPORTANT .. DON'T MISS THIS STEP**


### PR DESCRIPTION
Based on the [template file](https://learn-cantrill-labs.s3.amazonaws.com/aws-elastic-wordpress-evolution/A4LVPC.yaml) provided at video `[AdvancedDemo] Architecture Evolution - STAGE1 - PART2`, the VPC Security Group on STAGE3 has a typo.