### PR TITLE
libyang error in aws-hybrid-bgpvpn

### DIFF
--- a/aws-hybrid-bgpvpn/OnPremRouter1/ffrouting-install.sh
+++ b/aws-hybrid-bgpvpn/OnPremRouter1/ffrouting-install.sh
@@ -14,7 +14,7 @@ sudo apt-get install -y \
 cd /tmp
 git clone https://github.com/CESNET/libyang.git
 cd libyang
-git checkout v2.0.0
+git checkout v2.1.128
 mkdir build; cd build
 cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr \
       -DCMAKE_BUILD_TYPE:String="Release" ..

--- a/aws-hybrid-bgpvpn/OnPremRouter2/ffrouting-install.sh
+++ b/aws-hybrid-bgpvpn/OnPremRouter2/ffrouting-install.sh
@@ -14,7 +14,7 @@ sudo apt-get install -y \
 cd /tmp
 git clone https://github.com/CESNET/libyang.git
 cd libyang
-git checkout v2.0.0
+git checkout v2.1.128
 mkdir build; cd build
 cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr \
       -DCMAKE_BUILD_TYPE:String="Release" ..


### PR DESCRIPTION
libyang error was fixed by changing the version to v2.1.128 in both ffrouting-install.sh files on line 17

error after running command ./ffrouting-install.sh
***************************************************
checking for LIBYANG (libyang >= 2.1.128)... no
configure: error: libyang >= 2.1.128 is required, and was not found on your system. 