### PR TITLE
fix "mysql: command not found" in later Stage 5 by updating Stage 4 instructions

### DIFF
--- a/aws-elastic-wordpress-evolution/02_LABINSTRUCTIONS/STAGE4 - Add EFS and Update the LT.md
+++ b/aws-elastic-wordpress-evolution/02_LABINSTRUCTIONS/STAGE4 - Add EFS and Update the LT.md
@@ -142,9 +142,9 @@ EFSFSID=`echo $EFSFSID | sed -e 's/^"//' -e 's/"$//'`
 
 ```
 
-Find the line which says `dnf install wget php-mysqlnd httpd php-fpm php-mysqli php-json php php-devel stress -y`
+Find the line which says `dnf install wget php-mysqlnd httpd php-fpm php-mysqli mariadb105-server php-json php php-devel stress -y`
 after `stress` add a space and paste in `amazon-efs-utils`  
-it should now look like `dnf install wget php-mysqlnd httpd php-fpm php-mysqli php-json php php-devel stress amazon-efs-utils -y`  
+it should now look like `dnf install wget php-mysqlnd httpd php-fpm php-mysqli mariadb105-server php-json php php-devel stress amazon-efs-utils -y`  
 
 locate `systemctl start httpd` position cursor at the end & press enter twice to add new lines  
 


### PR DESCRIPTION
fix "mysql: command not found" in later Stage 5

Without the package "mariadb105-server" the shell script in the later stage 5 can't execute because:

`[root@ip-10-16-59-138 ec2-user]# ./update_wp_ip.sh
./update_wp_ip.sh: line 4: mysql: command not found
./update_wp_ip.sh: line 9: mysql: command not found
./update_wp_ip.sh: line 10: mysql: command not found
./update_wp_ip.sh: line 11: mysql: command not found
./update_wp_ip.sh: line 12: mysql: command not found`