### PR TITLE
Fix "401 - Unauthorized" when retrieving instance meta data

### DIFF
--- a/aws-dms-database-migration/02_LABINSTRUCTIONS/STAGE4 - Migrate Database & Cutover.md
+++ b/aws-dms-database-migration/02_LABINSTRUCTIONS/STAGE4 - Migrate Database & Cutover.md
@@ -124,7 +124,8 @@ Run the script below, to update the wordpress database with the new instance DNS
 source <(php -r 'require("/var/www/html/wp-config.php"); echo("DB_NAME=".DB_NAME."; DB_USER=".DB_USER."; DB_PASSWORD=".DB_PASSWORD."; DB_HOST=".DB_HOST); ')
 SQL_COMMAND="mysql -u $DB_USER -h $DB_HOST -p$DB_PASSWORD $DB_NAME -e"
 OLD_URL=$(mysql -u $DB_USER -h $DB_HOST -p$DB_PASSWORD $DB_NAME -e 'select option_value from wp_options where option_id = 1;' | grep http)
-HOST=$(curl http://169.254.169.254/latest/meta-data/public-hostname)
+TOKEN=`curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600"`
+HOST=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/public-hostname)
 $SQL_COMMAND "UPDATE wp_options SET option_value = replace(option_value, '$OLD_URL', 'http://$HOST') WHERE option_name = 'home' OR option_name = 'siteurl';"
 $SQL_COMMAND "UPDATE wp_posts SET guid = replace(guid, '$OLD_URL','http://$HOST');"
 $SQL_COMMAND "UPDATE wp_posts SET post_content = replace(post_content, '$OLD_URL', 'http://$HOST');"


### PR DESCRIPTION
When running the script to update the Wordpress DB to point to the DNS name of the RDS instance it fails because the instance's meta data is not available without a token on newer EC2 instances.

E.g.: curl http://169.254.169.254/latest/meta-data/public-hostname -> 401 Unauthorized

Instead get token first and then use the token to fetch meta data.
