### PR TITLE
aws-client-vpn ./easyrsa --san=DNS:server build-server-full

### DIFF
--- a/aws-client-vpn/02_LABINSTRUCTIONS/STAGE2.md
+++ b/aws-client-vpn/02_LABINSTRUCTIONS/STAGE2.md
@@ -26,7 +26,7 @@ This past of the demo involves downloading easy-rsa and using this to create cer
 - ./easyrsa init-pki
 - ./easyrsa build-ca nopass
 - - ANIMALS4LIFEVPN
-- ./easyrsa build-server-full server nopass
+- ./easyrsa --san=DNS:server build-server-full server nopass
 - aws acm import-certificate --certificate fileb://pki/issued/server.crt --private-key fileb://pki/private/server.key --certificate-chain fileb://pki/ca.crt --profile iamadmin-general
 
 ## Windows
@@ -37,7 +37,7 @@ This past of the demo involves downloading easy-rsa and using this to create cer
 - EasyRSA-Start
 - ./easyrsa init-pki
 - ./easyrsa build-ca nopass
-- ./easyrsa build-server-full server nopass
+- ./easyrsa --san=DNS:server build-server-full server nopass
 - ./easyrsa build-client-full client1.domain.tld nopass
 - exit
 


### PR DESCRIPTION
Fix for aws-client-vpn.

Right now the Server certificate ARN doesn't show in Create client VPN endpoint, to fix this

I changed
./easyrsa build-server-full server nopass
to
./easyrsa --san=DNS:server build-server-full server nopass

As in https://docs.aws.amazon.com/vpn/latest/clientvpn-admin/mutual.html