### PR TITLE
Adding FQDN used for Simple AD directory when generating certificate

### DIFF
--- a/aws-client-vpn/02_LABINSTRUCTIONS/STAGE2.md
+++ b/aws-client-vpn/02_LABINSTRUCTIONS/STAGE2.md
@@ -26,8 +26,8 @@ This past of the demo involves downloading easy-rsa and using this to create cer
 - ./easyrsa init-pki
 - ./easyrsa build-ca nopass
 - - ANIMALS4LIFEVPN
-- ./easyrsa build-server-full server nopass
-- aws acm import-certificate --certificate fileb://pki/issued/server.crt --private-key fileb://pki/private/server.key --certificate-chain fileb://pki/ca.crt --profile iamadmin-general
+- ./easyrsa build-server-full corp.animals4life.org nopass
+- aws acm import-certificate --certificate fileb://pki/issued/corp.animals4life.org.crt --private-key fileb://pki/private/corp.animals4life.org.key --certificate-chain fileb://pki/ca.crt --profile iamadmin-general
 
 ## Windows
 


### PR DESCRIPTION
Updated Stage 2 to include FQDN for easyra cert. Using the FQDN you use when creating the Simple AD directory, when you generate the certificate allows the ACM certificate to show in the AWS management console as a reference.

If you don't add this you cannot see any ACM certificate when you try to add it in the AWS management console.