### PR TITLE
Update SQL query of wp_options

### DIFF
--- a/aws-elastic-wordpress-evolution/02_LABINSTRUCTIONS/STAGE5 - Add an ELB and ASG.md
+++ b/aws-elastic-wordpress-evolution/02_LABINSTRUCTIONS/STAGE5 - Add an ELB and ASG.md
@@ -82,7 +82,7 @@ cat >> /home/ec2-user/update_wp_ip.sh<< 'EOF'
 #!/bin/bash
 source <(php -r 'require("/var/www/html/wp-config.php"); echo("DB_NAME=".DB_NAME."; DB_USER=".DB_USER."; DB_PASSWORD=".DB_PASSWORD."; DB_HOST=".DB_HOST); ')
 SQL_COMMAND="mysql -u $DB_USER -h $DB_HOST -p$DB_PASSWORD $DB_NAME -e"
-OLD_URL=$(mysql -u $DB_USER -h $DB_HOST -p$DB_PASSWORD $DB_NAME -e 'select option_value from wp_options where option_id = 1;' | grep http)
+OLD_URL=$($SQL_COMMAND 'select option_value from wp_options where option_name = '"'"'home'"'"';' | grep http)
 
 ALBDNSNAME=$(aws ssm get-parameters --region us-east-1 --names /A4L/Wordpress/ALBDNSNAME --query Parameters[0].Value)
 ALBDNSNAME=`echo $ALBDNSNAME | sed -e 's/^"//' -e 's/"$//'`


### PR DESCRIPTION
Option ID has changed? Use option_name instead, so ALB update is not broken in /home/ec2-user/update_wp_ip.sh