### PR TITLE
Update HybridDNS.yaml

### DIFF
--- a/aws-hybrid-dns/01_LABSETUP/HybridDNS.yaml
+++ b/aws-hybrid-dns/01_LABSETUP/HybridDNS.yaml
@@ -182,9 +182,7 @@ Resources:
             forwarders {
               192.168.10.2;
             };
-            dnssec-enable yes;
             dnssec-validation yes;
-            dnssec-lookaside auto;
             /* Path to ISC DLV key */
             bindkeys-file "/etc/named.iscdlv.key";
             managed-keys-directory "/var/named/dynamic";


### PR DESCRIPTION
Same change as https://github.com/acantril/learn-cantrill-io-labs/pull/175, I missed ONPREMDNSB and only updated A....


Remove deprecated values from /etc/named.conf
- `dnssec-enable yes;`
- `dnssec-lookaside auto;`


https://bind9.readthedocs.io/en/v9.16.16/notes.html#removed-features
