### PR TITLE
fix: remove unrecognized --enable-systemd option and custom prefix from ffrouting-install.sh

### DIFF
--- a/aws-hybrid-bgpvpn/OnPremRouter1/ffrouting-install.sh
+++ b/aws-hybrid-bgpvpn/OnPremRouter1/ffrouting-install.sh
@@ -8,7 +8,7 @@ sudo apt-get install -y \
    pkg-config libpam0g-dev libjson-c-dev bison flex python3-pytest \
    libc-ares-dev python3-dev libsystemd-dev python-ipaddress python3-sphinx \
    install-info build-essential libsystemd-dev libsnmp-dev perl libcap-dev \
-   libpcre3-dev libelf-dev libpcre2-dev cmake 
+   libpcre3-dev libelf-dev libpcre2-dev libunwind-dev cmake 
 
 # Libyang
 cd /tmp
@@ -53,26 +53,23 @@ cd frr
 ./configure \
     --prefix=/usr \
     --includedir=\${prefix}/include \
-    --enable-exampledir=\${prefix}/share/doc/frr/examples \
     --bindir=\${prefix}/bin \
     --sbindir=\${prefix}/lib/frr \
     --libdir=\${prefix}/lib/frr \
     --libexecdir=\${prefix}/lib/frr \
-    --localstatedir=/var/run/frr \
-    --sysconfdir=/etc/frr \
+    --localstatedir=/var \
+    --sysconfdir=/etc \
     --with-moduledir=\${prefix}/lib/frr/modules \
-    --with-libyang-pluginsdir=\${prefix}/lib/frr/libyang_plugins \
     --enable-configfile-mask=0640 \
     --enable-logfile-mask=0640 \
-    --enable-snmp=agentx \
+    --enable-snmp \
     --enable-multipath=64 \
     --enable-user=frr \
     --enable-group=frr \
     --enable-vty-group=frrvty \
-    --enable-systemd=yes \
-    --enable-rpki=yes \
     --with-pkg-git-version \
     --with-pkg-extra-version=-chriselsen
+    
 make
 sudo make install
 


### PR DESCRIPTION
The custom prefix caused compilation failures, I have updated the script following the updated documentation:
https://docs.frrouting.org/projects/dev-guide/en/latest/building-frr-for-ubuntu1804.html